### PR TITLE
add setCurrentWorkingDirectory() and call it in Start()

### DIFF
--- a/HaystackContinued/HaystackContinued.cs
+++ b/HaystackContinued/HaystackContinued.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using UnityEngine;
@@ -116,8 +117,26 @@ namespace HaystackReContinued
             this.WinVisible = !this.WinVisible;
         }
 
+        /*  Many mods assume that KSP will be operating with working directory set to its root directory,
+            containing KSP.x86_64 and GameData.  Doesn't hurt to set it though.
+
+            Furthermore, if this is done early enough in the executing KSP instance, it will apply to all
+            code (e.g. mods) executing thereafter.
+
+            Finally, if this change, applied here in HaystackContinued, is moved into a mod that is a)
+            almost ubiquitous and b) very likely to run early (e.g. ModuleManager?), it will have beneficial
+            effects on a far wider scale.  (KerbalKonstructs is another mod that is known to fail based on
+            this faulty assumption.)
+        */       
+        public void setCurrentWorkingDirectory()
+        {
+            string exeDir = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+            Directory.SetCurrentDirectory(exeDir);
+        }
+
         public void Start()
         {
+            setCurrentWorkingDirectory();
             // not an anonymous functions because we need to remove them in #OnDestroy
             GameEvents.onHideUI.Add(onHideUI);
             GameEvents.onShowUI.Add(onShowUI);


### PR DESCRIPTION
Problem: Haystack, like other mods, assumes the current working directory is set to the KSP root directory.

Solution: as soon as Haystack initializes, simply SetCurrentDirectory to GetExecutingAssembly.  All ensuing relative path references to GameData assets should then work.

It has the benefit that this will help other mods that run later that suffer the same faulty assumption.

If this same change was performed early enough, (e.g. in a mod such as ModuleManager?), it ought to have a wider, beneficial impact.

**NOTE BENE:** It appears HaystackContinued will not build on Linux (buildRelease.bat and a TextTransform.exe error), so this change has NOT been tested.  (Please advise course of action.)
